### PR TITLE
Fix for client side DoS during contest start

### DIFF
--- a/cms/server/static/cws_utils.js
+++ b/cms/server/static/cws_utils.js
@@ -37,6 +37,7 @@ CMS.CWSUtils = function(url_root, timestamp, timezoned_timestamp,
     this.phase = phase;
     this.remaining_div = null;
     this.unread_count = 0;
+    this.is_reloading = false;
 };
 
 
@@ -174,8 +175,9 @@ CMS.CWSUtils.prototype.update_time = function() {
     switch (this.phase) {
     case -2:
         // Contest hasn't started yet.
-        if (server_time >= this.current_phase_end) {
+        if (server_time >= this.current_phase_end && !this.is_reloading) {
             window.location.href = this.url_root + "/";
+            this.is_reloading = true;
         }
         $("#countdown_label").text(
             $("#translation_until_contest_starts").text());


### PR DESCRIPTION
This should stop client from the current behaviour - reloading every second until server responds within that period. Now, if server is in degraded state and responds slowly, client will wait until response is received or error is displayed (or they manually reload).

There are nicer ways of achieving this (e.g. adding exponential falloff), but I opted for simplest possible fix mitigating our problems.