### PR TITLE
Add optional python documentation support (python_doc_path).

### DIFF
--- a/cms/conf.py
+++ b/cms/conf.py
@@ -139,6 +139,7 @@ class Config:
         self.max_submission_length = 100_000  # 100 KB
         self.max_input_length = 5_000_000  # 5 MB
         self.stl_path = "/usr/share/cppreference/doc/html/"
+        self.python_doc_path = None
         # Prefix of 'shared-mime-info'[1] installation. It can be found
         # out using `pkg-config --variable=prefix shared-mime-info`, but
         # it's almost universally the same (i.e. '/usr') so it's hardly

--- a/cms/server/contest/handlers/main.py
+++ b/cms/server/contest/handlers/main.py
@@ -539,6 +539,7 @@ class DocumentationHandler(ContestHandler):
     @multi_contest
     def get(self):
         self.render("documentation.html",
+                    python_doc_configured=config.python_doc_path is not None,
                     COMPILATION_MESSAGES=COMPILATION_MESSAGES,
                     EVALUATION_MESSAGES=EVALUATION_MESSAGES,
                     **self.r_params)

--- a/cms/server/contest/server.py
+++ b/cms/server/contest/server.py
@@ -99,8 +99,14 @@ class ContestWebServer(WebService):
             shard=shard,
             listen_address=listen_address)
 
+        documentation_handlers = {
+            "/stl": config.stl_path,
+        }
+        if config.python_doc_path:
+            documentation_handlers["/python"] = config.python_doc_path
+
         self.wsgi_app = SharedDataMiddleware(
-            self.wsgi_app, {"/stl": config.stl_path},
+            self.wsgi_app, documentation_handlers,
             cache=True, cache_timeout=SECONDS_IN_A_YEAR,
             fallback_mimetype="application/octet-stream")
 

--- a/cms/server/contest/templates/documentation.html
+++ b/cms/server/contest/templates/documentation.html
@@ -23,6 +23,12 @@
 <p>{% trans %}The main Java class of the solution should have exactly the same name as the task.{% endtrans %}</p>
 {% endif %}
 
+{% if python_doc_configured and contest.languages|map("to_language")|map(attribute="source_extensions")|any("contains", ".py") %}
+<h3>Python</h3>
+
+<p><a href="{{ url("python", "index.html") }}">{% trans %}Documentation{% endtrans %}</a></p>
+{% endif %}
+
 
 <h2>{% trans %}Submission details for compilation{% endtrans %}</h2>
 

--- a/config/cms.conf.sample
+++ b/config/cms.conf.sample
@@ -137,6 +137,10 @@
     "_help": "STL documentation path in the system (exposed in CWS).",
     "stl_path": "/usr/share/cppreference/doc/html/",
 
+    "_help": "Python documentation path in the system (exposed in CWS).",
+    "_help": "This path is optional - if unset, the documentation handler",
+    "_help": "will not be exposed under /python.",
+    "python_doc_path": "/usr/share/doc/python3.7-doc/html/",
 
 
     "_section": "AdminWebServer",


### PR DESCRIPTION
There are two sides to this feature:
1. Conditionally exposing python documentation link under documentation page.

2. Conditionally constructing /python documentation handler. In most cases it's not necessary (e.g. contests without python language support), so if the configuration field `python_doc_path` is not set, the handler is not exposed.